### PR TITLE
* Moving some necessary defines from HardwareSerial.cpp to HardwareSeria...

### DIFF
--- a/hardware/DynamicPerception/avr/cores/AT90USB/Arduino.h
+++ b/hardware/DynamicPerception/avr/cores/AT90USB/Arduino.h
@@ -202,6 +202,7 @@ extern const uint8_t PROGMEM digital_pin_to_timer_PGM[];
 #include "WString.h"
 #include "HardwareSerial.h"
 
+
 uint16_t makeWord(uint16_t w);
 uint16_t makeWord(byte h, byte l);
 

--- a/hardware/DynamicPerception/avr/cores/AT90USB/HardwareSerial.cpp
+++ b/hardware/DynamicPerception/avr/cores/AT90USB/HardwareSerial.cpp
@@ -44,35 +44,10 @@
 
 #include "HardwareSerial.h"
 
-/*
- * on ATmega8, the uart and its bits are not numbered, so there is no "TXC0"
- * definition.
- */
-#if !defined(TXC0)
-#if defined(TXC)
-#define TXC0 TXC
-#elif defined(TXC1)
-// Some devices have uart1 but no uart0
-#define TXC0 TXC1
-#else
-#error TXC0 not definable in HardwareSerial.h
-#endif
-#endif
+
 
 uint8_t _pin = 0;
 float SER_CLEAR_TM = 0.0;
-
-// Define constants and variables for buffering incoming serial data.  We're
-// using a ring buffer (I think), in which head is the index of the location
-// to which to write the next incoming character and tail is the index of the
-// location from which to read.
-
-// Do not set to 256 or higher because head and tail are uint8_t for atomic access - JM
-#if (RAMEND < 1000)
-  #define SERIAL_BUFFER_SIZE 16
-#else
-  #define SERIAL_BUFFER_SIZE 64
-#endif
 
 struct ring_buffer
 {

--- a/hardware/DynamicPerception/avr/cores/AT90USB/HardwareSerial.h
+++ b/hardware/DynamicPerception/avr/cores/AT90USB/HardwareSerial.h
@@ -104,6 +104,34 @@ class HardwareSerial : public Stream
 #define SERIAL_7O2 0x3C
 #define SERIAL_8O2 0x3E
 
+/*
+ * on ATmega8, the uart and its bits are not numbered, so there is no "TXC0"
+ * definition.
+ */
+#if !defined(TXC0)
+	#if defined(TXC)
+		#define TXC0 TXC
+	#elif defined(TXC1)
+		// Some devices have uart1 but no uart0
+		#define TXC0 TXC1
+	#else
+		#error TXC0 not definable in HardwareSerial.h
+	#endif
+#endif
+
+// Define constants and variables for buffering incoming serial data.  We're
+// using a ring buffer (I think), in which head is the index of the location
+// to which to write the next incoming character and tail is the index of the
+// location from which to read.
+
+// Do not set to 256 or higher because head and tail are uint8_t for atomic access - JM
+#if (RAMEND < 1000)
+  #define SERIAL_BUFFER_SIZE 16
+#else
+  #define SERIAL_BUFFER_SIZE 64
+#endif
+
+
     // Create correct Serial Devices based on 
     // Available serial registers, and compile-time
     // flags


### PR DESCRIPTION
TXC0 was getting defined in HardwareSerial.cpp instead of HardwareSerial.h for the AT90x boards.  This causes problems when the IDE's make chooses to compile the CPP file at a later point, and libraries/code need TXC0 defined.
